### PR TITLE
Add DBAL row iterator

### DIFF
--- a/src/DBAL/IteratorTrait.php
+++ b/src/DBAL/IteratorTrait.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\DoctrineExtra\DBAL;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Fazland\DoctrineExtra\IteratorTrait as BaseIteratorTrait;
+
+trait IteratorTrait
+{
+    use BaseIteratorTrait;
+
+    private QueryBuilder $queryBuilder;
+    private ?int $totalCount;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(): int
+    {
+        if (null === $this->totalCount) {
+            $queryBuilder = clone $this->queryBuilder;
+
+            $this->totalCount = (int) $queryBuilder->select('COUNT(*) AS sclr_0')
+                ->setFirstResult(null)
+                ->setMaxResults(null)
+                ->execute()->fetchColumn()
+            ;
+        }
+
+        return $this->totalCount;
+    }
+}

--- a/src/DBAL/RowIterator.php
+++ b/src/DBAL/RowIterator.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\DoctrineExtra\DBAL;
+
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Fazland\DoctrineExtra\ObjectIteratorInterface;
+
+class RowIterator implements ObjectIteratorInterface
+{
+    use IteratorTrait {
+        current as private iteratorCurrent;
+    }
+
+    private ?\ArrayIterator $internalIterator;
+
+    public function __construct(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = clone $queryBuilder;
+        $this->internalIterator = null;
+        $this->totalCount = null;
+
+        $this->apply();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        $this->current = null;
+
+        $iterator = $this->getIterator();
+
+        $iterator->next();
+        $this->currentElement = $iterator->valid() ? $iterator->current() : null;
+
+        return $this->current();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        return $this->getIterator()->key();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid(): bool
+    {
+        return $this->getIterator()->valid();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $this->getIterator();
+
+        return $this->iteratorCurrent();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind(): void
+    {
+        $this->current = null;
+        $this->getIterator()->rewind();
+        $this->currentElement = $this->internalIterator->current();
+    }
+
+    /**
+     * Gets the iterator.
+     */
+    private function getIterator(): \ArrayIterator
+    {
+        if (null !== $this->internalIterator) {
+            return $this->internalIterator;
+        }
+
+        $this->internalIterator = new \ArrayIterator($this->queryBuilder->execute()->fetchAll(FetchMode::ASSOCIATIVE));
+        $this->currentElement = $this->internalIterator->current();
+
+        return $this->internalIterator;
+    }
+}

--- a/tests/DBAL/RowIteratorTest.php
+++ b/tests/DBAL/RowIteratorTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Fazland\DoctrineExtra\Tests\ORM;
+
+use Doctrine\DBAL\Cache\ArrayStatement;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Fazland\DoctrineExtra\DBAL\RowIterator;
+use Fazland\DoctrineExtra\Tests\Mock\ORM\EntityManagerTrait;
+use PHPUnit\Framework\TestCase;
+
+class RowIteratorTest extends TestCase
+{
+    use EntityManagerTrait;
+
+    private QueryBuilder $queryBuilder;
+    private RowIterator $iterator;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->getEntityManager(); // Initialize connection
+
+        $this->queryBuilder = $this->connection->createQueryBuilder();
+        $this->queryBuilder->select('a.id')
+            ->from('foobar', 'a');
+
+        $this->innerConnection
+            ->query('SELECT a.id FROM foobar a')
+            ->willReturn(new ArrayStatement([
+                ['id' => '42'],
+                ['id' => '45'],
+                ['id' => '48'],
+            ]))
+        ;
+
+        $this->iterator = new RowIterator($this->queryBuilder);
+    }
+
+    public function testShouldBeIterable(): void
+    {
+        self::assertTrue(\is_iterable($this->iterator));
+    }
+
+    public function testShouldBeAnIterator(): void
+    {
+        self::assertInstanceOf(\Iterator::class, $this->iterator);
+    }
+
+    public function testCountShouldExecuteACountQuery(): void
+    {
+        $this->innerConnection
+            ->query('SELECT COUNT(*) AS sclr_0 FROM foobar a')
+            ->willReturn(new ArrayStatement([
+                ['sclr_0' => '42'],
+            ]))
+        ;
+
+        self::assertCount(42, $this->iterator);
+    }
+
+    public function testCountWithOffsetShouldExecuteACountQueryWithoutOffset(): void
+    {
+        $this->queryBuilder->setFirstResult(1);
+
+        $this->innerConnection
+            ->query('SELECT a.id FROM foobar a OFFSET 1')
+            ->willReturn(new ArrayStatement([
+                ['id_0' => '42'],
+                ['id_0' => '45'],
+                ['id_0' => '48'],
+            ]));
+
+        $this->innerConnection
+            ->query('SELECT COUNT(*) AS sclr_0 FROM foobar a')
+            ->willReturn(new ArrayStatement([
+                ['sclr_0' => '42'],
+            ]))
+        ;
+
+        self::assertCount(42, new RowIterator($this->queryBuilder));
+    }
+
+    public function testShouldIterateAgainstAQueryResult(): void
+    {
+        $result = [
+            ['id' => 42],
+            ['id' => 45],
+            ['id' => 48],
+        ];
+
+        self::assertEquals($result, \iterator_to_array($this->iterator));
+    }
+
+    public function testShouldCallCallableSpecifiedWithApply(): void
+    {
+        $calledCount = 0;
+        $this->iterator->apply(function (array $row) use (&$calledCount): int {
+            ++$calledCount;
+
+            return (int) $row['id'];
+        });
+
+        self::assertEquals([42, 45, 48], \iterator_to_array($this->iterator));
+        self::assertEquals(3, $calledCount);
+    }
+}


### PR DESCRIPTION
Add an iterator operating on DBAL query builder (raw sql).
It is similar to the ORM/ODM ones, but emits associative arrays instead of objects while iterating.

Needed as a base for pager iterators on a raw sql processor in api-platform-bundle (already workin' on it).